### PR TITLE
Add Vercel deployment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ This is a simple Next.js application that generates game content using OpenAI Ch
 - API route `/api/generate` securely calls OpenAI using your API key.
 - Firebase support is included for optional history storage.
 
+## Deployment
+
+Deploy this project on Vercel using the **Next.js** preset. When Vercel detects a
+Next.js app it automatically handles the build output, so no `public` directory
+is produced. A `vercel.json` file is unnecessary unless you need custom routing
+or overrides, because the default Next.js configuration is applied
+automatically.
+


### PR DESCRIPTION
## Summary
- document that the project should be deployed as a Next.js app on Vercel
- mention that Next.js doesn't output a `public` directory
- note that `vercel.json` isn't required when framework detection works

## Testing
- `npm run build` *(fails: next not found)*