### PR TITLE
Add check for missing OpenAI key

### DIFF
--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -17,6 +17,12 @@ export default async function handler(req, res) {
 
   const prompt = buildPrompt(template, brandTone, useCase);
 
+  if (!process.env.OPENAI_API_KEY) {
+    return res
+      .status(500)
+      .json({ error: 'OPENAI_API_KEY environment variable is not set' });
+  }
+
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` before sending requests to OpenAI

## Testing
- `npm test` *(fails: Missing script)*