### PR TITLE
Fix Vercel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,12 @@ Deploy this project on Vercel using the **Next.js** preset. When Vercel detects 
 Next.js app it automatically handles the build output, so no `public` directory
 is produced. A `vercel.json` file is unnecessary unless you need custom routing
 or overrides, because the default Next.js configuration is applied
-automatically.
+automatically. If you previously added a `vercel.json` with a custom
+`outputDirectory`, remove those overrides or replace the file with:
+
+```json
+{
+  "framework": "nextjs"
+}
+```
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- clarify deployment instructions about removing the `outputDirectory` override
- add minimal `vercel.json` so Vercel treats this as a Next.js app

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.