### PR TITLE
Use env vars for Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ This is a simple Next.js application that generates game content using OpenAI Ch
 2. Install dependencies with `npm install`.
 3. Run the development server using `npm run dev`.
 
+### Required Environment Variables
+
+The app expects the following variables in `.env.local`:
+
+```
+OPENAI_API_KEY
+NEXT_PUBLIC_FIREBASE_API_KEY
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+NEXT_PUBLIC_FIREBASE_PROJECT_ID
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+NEXT_PUBLIC_FIREBASE_APP_ID
+```
+
 ## Features
 
 - Select a game template and generate content based on brand tone and use case.

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -3,15 +3,16 @@ import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyDBYQHhoWwLYu2N2QFBG-zTjRiYdW305RM",
-  authDomain: "mtb-ai-5fbea.firebaseapp.com",
-  projectId: "mtb-ai-5fbea",
-  storageBucket: "mtb-ai-5fbea.firebasestorage.app",
-  messagingSenderId: "990228774847",
-  appId: "1:990228774847:web:cff9217b936285d270eb0a"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
 export { db };
+export default db;


### PR DESCRIPTION
## Summary
- load Firebase config from environment variables
- export the Firestore db as a default
- document required variables in the README

## Testing
- `npm run build` *(fails: next not found)*