### PR TITLE
Support Firestore game type in API

### DIFF
--- a/utils/buildPrompt.js
+++ b/utils/buildPrompt.js
@@ -4,5 +4,13 @@ export default function buildPrompt(template, brandTone, useCase) {
   }
   const tone = brandTone ? `Tone: ${brandTone}.` : '';
   const usage = useCase ? `Use case: ${useCase}.` : '';
-  return `${template.description}\n${tone}\n${usage}\n\nInstructions: ${template.formatInstruction}`.trim();
+  let extra = '';
+  if (template.formatInstruction) {
+    extra = `Instructions: ${template.formatInstruction}`;
+  } else {
+    const cases = template.useCases ? `Use Cases: ${template.useCases}` : '';
+    const mech = template.mechanics ? `Game Mechanics: ${template.mechanics}` : '';
+    extra = `${cases}\n${mech}`.trim();
+  }
+  return `${template.description}\n${tone}\n${usage}\n\n${extra}`.trim();
 }


### PR DESCRIPTION
## Summary
- fetch missing template from Firestore in `generate` API
- support building prompts from Firestore fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*