### PR TITLE
Add reusable CSS classes

### DIFF
--- a/components/GameTypeSettings.tsx
+++ b/components/GameTypeSettings.tsx
@@ -83,10 +83,10 @@ const GameTypeSettings = () => {
 
   return (
     <div>
-      <button onClick={() => setOpen(true)} className="px-2 py-1 bg-gray-700 rounded">Settings</button>
+      <button onClick={() => setOpen(true)} className="btn btn-neutral">Settings</button>
       {open && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-10">
-          <div className="bg-[#212121] p-4 rounded w-full max-w-lg max-h-full overflow-auto">
+        <div className="modal-overlay">
+          <div className="modal-content">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-xl font-bold">Game Types</h2>
               <button onClick={() => setOpen(false)} className="text-sm">Close</button>
@@ -97,33 +97,33 @@ const GameTypeSettings = () => {
                   {editMode ? (
                     <div className="space-y-2">
                       <input
-                        className="w-full p-1 text-black rounded"
+                        className="form-input-light"
                         placeholder="Name"
                         value={gt.name}
                         disabled={!gt.isNew}
                         onChange={(e) => handleChange(idx, 'name', e.target.value)}
                       />
                       <input
-                        className="w-full p-1 text-black rounded"
+                        className="form-input-light"
                         placeholder="Description"
                         value={gt.description}
                         onChange={(e) => handleChange(idx, 'description', e.target.value)}
                       />
                       <input
-                        className="w-full p-1 text-black rounded"
+                        className="form-input-light"
                         placeholder="Use Cases"
                         value={gt.useCases}
                         onChange={(e) => handleChange(idx, 'useCases', e.target.value)}
                       />
                       <input
-                        className="w-full p-1 text-black rounded"
+                        className="form-input-light"
                         placeholder="Mechanics"
                         value={gt.mechanics}
                         onChange={(e) => handleChange(idx, 'mechanics', e.target.value)}
                       />
                       <div className="flex space-x-2">
-                        <button onClick={() => saveGameType(gt)} className="px-2 py-1 bg-green-600 rounded">Save</button>
-                        <button onClick={() => deleteGameType(idx)} className="px-2 py-1 bg-red-600 rounded">Delete</button>
+                        <button onClick={() => saveGameType(gt)} className="btn btn-success">Save</button>
+                        <button onClick={() => deleteGameType(idx)} className="btn btn-danger">Delete</button>
                       </div>
                     </div>
                   ) : (
@@ -138,10 +138,10 @@ const GameTypeSettings = () => {
               ))}
             </ul>
             {editMode && (
-              <button onClick={addGameType} className="mt-4 px-2 py-1 bg-blue-600 rounded">Add Game Type</button>
+              <button onClick={addGameType} className="btn btn-blue mt-4">Add Game Type</button>
             )}
             {!editMode && (
-              <button onClick={requestEdit} className="mt-4 px-2 py-1 bg-gray-600 rounded">Edit</button>
+              <button onClick={requestEdit} className="btn btn-neutral mt-4">Edit</button>
             )}
           </div>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -69,7 +69,7 @@ export default function Home() {
           <select
             value={templateName}
             onChange={(e) => setTemplateName(e.target.value)}
-            className="w-full bg-[#2C2C2C] text-white p-[5px] border border-[#393939] rounded-[8px]"
+            className="form-control"
           >
             {gameTypes.map((t) => (
               <option key={t.name} value={t.name}>{t.name}</option>
@@ -82,7 +82,7 @@ export default function Home() {
             type="text"
             value={brandTone}
             onChange={(e) => setBrandTone(e.target.value)}
-            className="w-full bg-[#2C2C2C] text-white p-[5px] border border-[#393939] rounded-[8px]"
+            className="form-control"
           />
         </div>
         <div>
@@ -90,12 +90,12 @@ export default function Home() {
           <textarea
             value={useCase}
             onChange={(e) => setUseCase(e.target.value)}
-            className="w-full bg-[#2C2C2C] text-white p-[5px] border border-[#393939] rounded-[8px]"
+            className="form-control"
           />
         </div>
         <button
           type="submit"
-          className="bg-[#feb710] text-[#121212] px-[10px] py-[10px] rounded-[100px] block mx-auto"
+          className="btn btn-primary block mx-auto"
           disabled={loading}
         >
           {loading ? 'Generating...' : 'GENERATE'}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,3 +10,46 @@ body {
   font-family: 'Space Grotesk', sans-serif;
   padding: 20px;
 }
+
+/* Form controls */
+.form-control {
+  @apply w-full bg-[#2C2C2C] text-white p-2 border border-[#393939] rounded-md;
+}
+
+.form-input-light {
+  @apply w-full p-1 text-black rounded-md;
+}
+
+/* Buttons */
+.btn {
+  @apply px-4 py-2 rounded-md font-semibold;
+}
+
+.btn-primary {
+  @apply bg-[#feb710] text-[#121212];
+}
+
+.btn-neutral {
+  @apply bg-gray-700 text-white;
+}
+
+.btn-success {
+  @apply bg-green-600 text-white;
+}
+
+.btn-danger {
+  @apply bg-red-600 text-white;
+}
+
+.btn-blue {
+  @apply bg-blue-600 text-white;
+}
+
+/* Modal dialog */
+.modal-overlay {
+  @apply fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-10;
+}
+
+.modal-content {
+  @apply bg-[#212121] p-4 rounded-md w-full max-w-lg max-h-full overflow-auto;
+}


### PR DESCRIPTION
## Summary
- add reusable form, button and modal CSS classes
- refactor components to use the new classes for consistent style

## Testing
- `npm run build` *(fails: next not found)*