### PR TITLE
Set white text color in light input fields

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,7 +17,7 @@ body {
 }
 
 .form-input-light {
-  @apply w-full p-1 text-black rounded-md;
+  @apply w-full p-1 text-white rounded-md;
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- set white text in `.form-input-light` inputs so typed text is visible

## Testing
- `npm test` *(fails: Missing script)*